### PR TITLE
Adding deluge web support

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3,6 +3,7 @@ from flask import Flask, request, render_template, jsonify
 from bs4 import BeautifulSoup
 from qbittorrentapi import Client
 from transmission_rpc import Client as transmissionrpc
+from deluge_web_client import DelugeWebClient as delugewebclient
 from dotenv import load_dotenv
 app = Flask(__name__)
 

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,3 +4,4 @@ beautifulsoup4
 qbittorrent-api
 python-dotenv
 transmission-rpc
+deluge-web-client


### PR DESCRIPTION
This seems to work for me with.  One potential issue is I had to make a new environment variable called DL_URL since deluge_web also wanted http vs https.  I could have also made a new variable for http vs https and then concatenate that with host and port.  Let me know what you prefer