### PR TITLE
Add support for transmission client path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # AudiobookBay Automated
 
 AudiobookBay Automated is a lightweight web application designed to simplify audiobook management. It allows users to search [**AudioBook Bay**](https://audiobookbay.lu/) for audiobooks and send magnet links directly to a designated **Deludge, qBittorrent or Transmission** client.
@@ -48,6 +47,7 @@ DL_PASSWORD=YOUR_PASSWORD      # torrent password
 DL_CATEGORY=abb-downloader     # torrent category for downloads
 SAVE_PATH_BASE=/audiobooks     # Root path for audiobook downloads (relative to torrent)
 ABB_HOSTNAME='audiobookbay.is' #Default
+DL_PATH=/transmission/rpc      # Path for Transmission client
 ```
 The following optional variables add an additional entry to the navigation bar. This is useful for linking to your audiobook player or another related service:
 
@@ -81,6 +81,7 @@ NAV_LINK_URL=https://audiobooks.yourdomain.com/
          - ABB_HOSTNAME='audiobookbay.is' #Default
          - NAV_LINK_NAME=Open Audiobook Player #Optional
          - NAV_LINK_URL=https://audiobooks.yourdomain.com/ #Optional
+         - DL_PATH=/transmission/rpc # Optional Path for Transmission client
    ```
 
 2. **Start the Application**:
@@ -105,6 +106,7 @@ NAV_LINK_URL=https://audiobooks.yourdomain.com/
     DL_PASSWORD=pass
     DL_CATEGORY=abb-downloader
     SAVE_PATH_BASE=/audiobooks
+    DL_PATH=/transmission/rpc # Path for Transmission client
     
     # AudiobookBar Hostname
     ABB_HOSTNAME='audiobookbay.is' #Default

--- a/app/app.py
+++ b/app/app.py
@@ -165,7 +165,7 @@ def send():
             return jsonify({'message': 'Failed to extract magnet link'}), 500
 
         save_path = f"{SAVE_PATH_BASE}/{sanitize_title(title)}"
-        
+
         if DOWNLOAD_CLIENT == 'qbittorrent':
             qb = Client(host=DL_HOST, port=DL_PORT, username=DL_USERNAME, password=DL_PASSWORD)
             qb.auth_log_in()
@@ -187,7 +187,8 @@ def send():
 def status():
     try:
         if DOWNLOAD_CLIENT == 'transmission':
-            transmission = transmissionrpc(host=DL_HOST, port=DL_PORT, path=DL_PATH, username=DL_USERNAME, password=DL_PASSWORD)            torrents = transmission.get_torrents()
+            transmission = transmissionrpc(host=DL_HOST, port=DL_PORT, protocol=DL_SCHEME, path=DL_PATH, username=DL_USERNAME, password=DL_PASSWORD)
+            torrents = transmission.get_torrents()
             torrent_list = [
                 {
                     'name': torrent.name,

--- a/app/app.py
+++ b/app/app.py
@@ -33,6 +33,7 @@ DL_USERNAME = os.getenv("DL_USERNAME")
 DL_PASSWORD = os.getenv("DL_PASSWORD")
 DL_CATEGORY = os.getenv("DL_CATEGORY", "Audiobookbay-Audiobooks")
 SAVE_PATH_BASE = os.getenv("SAVE_PATH_BASE")
+DL_PATH = os.getenv("DL_PATH", "/transmission/rpc")  # Added DL_PATH environment variable
 
 # Custom Nav Link Variables
 NAV_LINK_NAME = os.getenv("NAV_LINK_NAME")
@@ -49,6 +50,7 @@ print(f"DL_CATEGORY: {DL_CATEGORY}")
 print(f"SAVE_PATH_BASE: {SAVE_PATH_BASE}")
 print(f"NAV_LINK_NAME: {NAV_LINK_NAME}")
 print(f"NAV_LINK_URL: {NAV_LINK_URL}")
+print(f"DL_PATH: {DL_PATH}")  # Print DL_PATH configuration
 
 
 @app.context_processor
@@ -169,7 +171,7 @@ def send():
             qb.auth_log_in()
             qb.torrents_add(urls=magnet_link, save_path=save_path, category=DL_CATEGORY)
         elif DOWNLOAD_CLIENT == 'transmission':
-            transmission = transmissionrpc(host=DL_HOST, port=DL_PORT, protocol=DL_SCHEME, username=DL_USERNAME, password=DL_PASSWORD)
+            transmission = transmissionrpc(host=DL_HOST, port=DL_PORT, protocol=DL_SCHEME, path=DL_PATH, username=DL_USERNAME, password=DL_PASSWORD)
             transmission.add_torrent(magnet_link, download_dir=save_path)
         elif DOWNLOAD_CLIENT == "delugeweb":
             delugeweb = delugewebclient(url=DL_URL, password=DL_PASSWORD)
@@ -185,8 +187,7 @@ def send():
 def status():
     try:
         if DOWNLOAD_CLIENT == 'transmission':
-            transmission = transmissionrpc(host=DL_HOST, port=DL_PORT, username=DL_USERNAME, password=DL_PASSWORD)
-            torrents = transmission.get_torrents()
+            transmission = transmissionrpc(host=DL_HOST, port=DL_PORT, path=DL_PATH, username=DL_USERNAME, password=DL_PASSWORD)            torrents = transmission.get_torrents()
             torrent_list = [
                 {
                     'name': torrent.name,

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,5 +16,6 @@ services:
       - SAVE_PATH_BASE=${SAVE_PATH_BASE}
       - NAV_LINK_NAME=${NAV_LINK_NAME}
       - NAV_LINK_URL=${NAV_LINK_URL}
+      - DL_PATH=${DL_PATH}
     env_file:
       - .env


### PR DESCRIPTION
Support for custom transmission path ( for example in my case its "/rpc" ). Also fixed status page, missing protocol for transmission.

Done mainly with copilot workspace:

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/JamesRy96/audiobookbay-automated/pull/16?shareId=76508fc6-c852-4fce-8c0d-322311936ad4).